### PR TITLE
Feature/cucumber4 plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ To use this adaptor with Cucumber 5 you have to add the following dependency:
 
 Also you have to add plugin `aquality.tracking.integrations.cucumber5jvm.AqualityTrackingCucumber5Jvm` to the Cucumber Test Runner. 
 
+## Cucumber 4 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.aquality-automation/aquality-tracking-cucumber4-jvm/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.aquality-automation/aquality-tracking-cucumber4-jvm)
+
+To use this adaptor with Cucumber 4 you have to add the following dependency:
+
+```xml
+<dependency>
+    <groupId>com.github.aquality-automation</groupId>
+    <artifactId>aquality-tracking-cucumber4-jvm</artifactId>
+    <version>$LATEST_VERSION</version>
+</dependency>
+```
+
+Also you have to add plugin `aquality.tracking.integrations.cucumber4jvm.AqualityTrackingCucumber4Jvm` to the Cucumber Test Runner.
+
 #### How to increase version for all modules
 
 ```bash

--- a/aquality-tracking-cucumber4-jvm/pom.xml
+++ b/aquality-tracking-cucumber4-jvm/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>aquality-tracking-cucumber4-jvm</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <parent>
         <artifactId>aquality-tracking-integrations</artifactId>
         <groupId>com.github.aquality-automation</groupId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <name>Aquality Tracking Cucumber 5 JVM</name>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.github.aquality-automation</groupId>
             <artifactId>aquality-tracking-integrations-core</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>

--- a/aquality-tracking-cucumber4-jvm/pom.xml
+++ b/aquality-tracking-cucumber4-jvm/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>aquality-tracking-cucumber4-jvm</artifactId>
+    <version>1.1.0</version>
+    <packaging>jar</packaging>
+
+    <parent>
+        <artifactId>aquality-tracking-integrations</artifactId>
+        <groupId>com.github.aquality-automation</groupId>
+        <version>1.1.0</version>
+    </parent>
+
+    <name>Aquality Tracking Cucumber 5 JVM</name>
+    <description>Aquality Tracking integration for Cucumber 5 JVM.</description>
+    <url>https://github.com/aquality-automation/aquality-tracking-integrations-java</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>4.8.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.aquality-automation</groupId>
+            <artifactId>aquality-tracking-integrations-core</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.10</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/aquality-tracking-cucumber4-jvm/src/main/java/aquality/tracking/integrations/cucumber4jvm/AqualityTrackingCucumber4Jvm.java
+++ b/aquality-tracking-cucumber4-jvm/src/main/java/aquality/tracking/integrations/cucumber4jvm/AqualityTrackingCucumber4Jvm.java
@@ -1,21 +1,22 @@
-package aquality.tracking.integrations.cucumber5jvm;
+package aquality.tracking.integrations.cucumber4jvm;
 
 import aquality.tracking.integrations.core.AqualityTrackingLifecycle;
-import io.cucumber.plugin.ConcurrentEventListener;
-import io.cucumber.plugin.event.*;
+import cucumber.api.event.*;
+
+import java.util.UUID;
 
 import static java.lang.String.format;
 
-public class AqualityTrackingCucumber5Jvm implements ConcurrentEventListener {
+public class AqualityTrackingCucumber4Jvm implements ConcurrentEventListener {
 
     private final AqualityTrackingLifecycle lifecycle;
 
-    public AqualityTrackingCucumber5Jvm() {
+    public AqualityTrackingCucumber4Jvm() {
         lifecycle = new AqualityTrackingLifecycle();
     }
 
     @Override
-    public void setEventPublisher(final EventPublisher eventPublisher) {
+    public void setEventPublisher(EventPublisher eventPublisher) {
         if (lifecycle.isEnabled()) {
             eventPublisher.registerHandlerFor(TestRunStarted.class, this::handleTestRunStartedEvent);
             eventPublisher.registerHandlerFor(TestRunFinished.class, this::handleTestRunFinishedEvent);
@@ -41,13 +42,13 @@ public class AqualityTrackingCucumber5Jvm implements ConcurrentEventListener {
     }
 
     private void handleTestCaseFinishedEvent(final TestCaseFinished event) {
-        TestCaseResultParser testCaseResultParser = new TestCaseResultParser(event.getResult());
+        TestCaseResultParser testCaseResultParser = new TestCaseResultParser(event.result);
         TestCaseResultParser.TestCaseResult testCaseResult = testCaseResultParser.parse();
         lifecycle.finishTestExecution(testCaseResult.getFinalResultId(), testCaseResult.getFailReason());
     }
 
     private void handleEmbedEvent(final EmbedEvent event) {
-        String fileName = format("%s_%s", event.getTestCase().getId(), event.getName());
-        lifecycle.addAttachment(fileName, event.getData());
+        String fileName = format("%s_%s", UUID.randomUUID(), event.name);
+        lifecycle.addAttachment(fileName, event.data);
     }
 }

--- a/aquality-tracking-cucumber4-jvm/src/main/java/aquality/tracking/integrations/cucumber4jvm/TestCaseNameParser.java
+++ b/aquality-tracking-cucumber4-jvm/src/main/java/aquality/tracking/integrations/cucumber4jvm/TestCaseNameParser.java
@@ -1,14 +1,19 @@
-package aquality.tracking.integrations.cucumber5jvm;
+package aquality.tracking.integrations.cucumber4jvm;
 
-import io.cucumber.core.internal.gherkin.AstBuilder;
-import io.cucumber.core.internal.gherkin.Parser;
-import io.cucumber.core.internal.gherkin.TokenMatcher;
-import io.cucumber.core.internal.gherkin.ast.Feature;
-import io.cucumber.core.internal.gherkin.ast.GherkinDocument;
-import io.cucumber.core.internal.gherkin.ast.ScenarioOutline;
-import io.cucumber.core.internal.gherkin.ast.TableRow;
-import io.cucumber.plugin.event.TestCase;
+import aquality.tracking.integrations.core.AqualityUncheckedException;
+import cucumber.api.TestCase;
+import gherkin.AstBuilder;
+import gherkin.Parser;
+import gherkin.TokenMatcher;
+import gherkin.ast.Feature;
+import gherkin.ast.GherkinDocument;
+import gherkin.ast.ScenarioOutline;
+import gherkin.ast.TableRow;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -33,7 +38,15 @@ class TestCaseNameParser {
     private Feature getCurrentFeature() {
         Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
         TokenMatcher matcher = new TokenMatcher();
-        GherkinDocument gherkinDocument = parser.parse(getFileSource(testCase.getUri()), matcher);
+        GherkinDocument gherkinDocument;
+        try {
+            String relativePathToFeatureFile = new URI(testCase.getUri()).getSchemeSpecificPart();
+            Path pathToFeatureFile = Paths.get(System.getProperty("user.dir"), relativePathToFeatureFile);
+
+            gherkinDocument = parser.parse(getFileSource(pathToFeatureFile), matcher);
+        } catch (URISyntaxException e) {
+            throw new AqualityUncheckedException(format("Failed to find feature file with URI: %s", testCase.getUri()), e);
+        }
         return gherkinDocument.getFeature();
     }
 

--- a/aquality-tracking-cucumber4-jvm/src/main/java/aquality/tracking/integrations/cucumber4jvm/TestCaseNameParser.java
+++ b/aquality-tracking-cucumber4-jvm/src/main/java/aquality/tracking/integrations/cucumber4jvm/TestCaseNameParser.java
@@ -54,8 +54,7 @@ class TestCaseNameParser {
         List<TableRow> examplesTableRows = feature.getChildren().stream()
                 .filter(child -> child.getName().equals(testCaseName))
                 .filter(child -> child instanceof ScenarioOutline)
-                .map(node -> (ScenarioOutline) node)
-                .map(outline -> outline.getExamples().get(0))
+                .map(node -> ((ScenarioOutline) node).getExamples().get(0))
                 .flatMap(examples -> examples.getTableBody().stream())
                 .collect(Collectors.toList());
 

--- a/aquality-tracking-cucumber4-jvm/src/main/java/aquality/tracking/integrations/cucumber4jvm/TestCaseResultParser.java
+++ b/aquality-tracking-cucumber4-jvm/src/main/java/aquality/tracking/integrations/cucumber4jvm/TestCaseResultParser.java
@@ -1,0 +1,57 @@
+package aquality.tracking.integrations.cucumber4jvm;
+
+import aquality.tracking.integrations.core.FinalResultId;
+import cucumber.api.Result;
+import lombok.Data;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import static java.lang.String.format;
+
+class TestCaseResultParser {
+
+    private final Result result;
+
+    TestCaseResultParser(Result result) {
+        this.result = result;
+    }
+
+    TestCaseResult parse() {
+        TestCaseResult testCaseResult = new TestCaseResult();
+        switch (result.getStatus()) {
+            case PASSED:
+                testCaseResult.setFinalResultId(FinalResultId.PASSED);
+                break;
+            case FAILED:
+                testCaseResult.setFinalResultId(FinalResultId.FAILED);
+                testCaseResult.setFailReason(formatErrorMessage(result.getError()));
+                break;
+            case PENDING:
+                testCaseResult.setFinalResultId(FinalResultId.PENDING);
+                testCaseResult.setFailReason(getShortErrorMessage(result.getError()));
+                break;
+            case SKIPPED:
+                testCaseResult.setFinalResultId(FinalResultId.PENDING);
+                testCaseResult.setFailReason("Test skipped");
+                break;
+            default:
+                testCaseResult.setFinalResultId(FinalResultId.NOT_EXECUTED);
+        }
+        return testCaseResult;
+    }
+
+    private String formatErrorMessage(final Throwable error) {
+        final String message = getShortErrorMessage(error);
+        final String stackTrace = ExceptionUtils.getStackTrace(error);
+        return format("Message:%n%s%n%nStack Trace:%n%s", message, stackTrace);
+    }
+
+    private String getShortErrorMessage(final Throwable error) {
+        return error.getMessage().split("\n")[0];
+    }
+
+    @Data
+    static class TestCaseResult {
+        private int finalResultId;
+        private String failReason;
+    }
+}

--- a/aquality-tracking-cucumber5-jvm/pom.xml
+++ b/aquality-tracking-cucumber5-jvm/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>aquality-tracking-cucumber5-jvm</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <parent>
         <artifactId>aquality-tracking-integrations</artifactId>
         <groupId>com.github.aquality-automation</groupId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <name>Aquality Tracking Cucumber 5 JVM</name>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.github.aquality-automation</groupId>
             <artifactId>aquality-tracking-integrations-core</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>

--- a/aquality-tracking-cucumber5-jvm/src/main/java/aquality/tracking/integrations/cucumber5jvm/TestCaseNameParser.java
+++ b/aquality-tracking-cucumber5-jvm/src/main/java/aquality/tracking/integrations/cucumber5jvm/TestCaseNameParser.java
@@ -41,8 +41,7 @@ class TestCaseNameParser {
         List<TableRow> examplesTableRows = feature.getChildren().stream()
                 .filter(child -> child.getName().equals(testCaseName))
                 .filter(child -> child instanceof ScenarioOutline)
-                .map(node -> (ScenarioOutline) node)
-                .map(outline -> outline.getExamples().get(0))
+                .map(node -> ((ScenarioOutline) node).getExamples().get(0))
                 .flatMap(examples -> examples.getTableBody().stream())
                 .collect(Collectors.toList());
 

--- a/aquality-tracking-integrations-core/pom.xml
+++ b/aquality-tracking-integrations-core/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>aquality-tracking-integrations-core</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <parent>
         <artifactId>aquality-tracking-integrations</artifactId>
         <groupId>com.github.aquality-automation</groupId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <name>Aquality Tracking integrations core</name>

--- a/aquality-tracking-integrations-core/src/main/java/aquality/tracking/integrations/core/http/AqualityHttpClient.java
+++ b/aquality-tracking-integrations-core/src/main/java/aquality/tracking/integrations/core/http/AqualityHttpClient.java
@@ -44,7 +44,7 @@ public class AqualityHttpClient implements IHttpClient {
         List<Header> headers = new ArrayList<>();
         headers.add(getBasicAuthHeader());
         headers.add(new BasicHeader(HttpHeaders.ACCEPT, APPLICATION_JSON.getMimeType()));
-        headers.add(new BasicHeader(HttpHeaders.CONTENT_TYPE, WILDCARD.getMimeType()));
+        headers.add(new BasicHeader(HttpHeaders.ACCEPT, WILDCARD.getMimeType()));
         return headers;
     }
 

--- a/aquality-tracking-integrations-core/src/main/java/aquality/tracking/integrations/core/models/Test.java
+++ b/aquality-tracking-integrations-core/src/main/java/aquality/tracking/integrations/core/models/Test.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class Test {
     private Integer id;
     private String name;
+    private String body;
     @JsonProperty("project_id")
     private Integer projectId;
     private List<Suite> suites;

--- a/aquality-tracking-integrations-core/src/main/java/aquality/tracking/integrations/core/utilities/FileUtils.java
+++ b/aquality-tracking-integrations-core/src/main/java/aquality/tracking/integrations/core/utilities/FileUtils.java
@@ -5,6 +5,7 @@ import aquality.tracking.integrations.core.AqualityUncheckedException;
 import java.io.*;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -32,10 +33,14 @@ public class FileUtils {
     }
 
     public static String getFileSource(final URI uri) {
-        try (Stream<String> lines = Files.lines(Paths.get(uri))) {
+        return getFileSource(Paths.get(uri));
+    }
+
+    public static String getFileSource(final Path filePath) {
+        try (Stream<String> lines = Files.lines(filePath)) {
             return lines.collect(Collectors.joining(System.lineSeparator()));
         } catch (IOException e) {
-            throw new AqualityUncheckedException(format("File %s not found.", uri), e);
+            throw new AqualityUncheckedException(format("File %s not found.", filePath), e);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <modules>
         <module>aquality-tracking-integrations-core</module>
         <module>aquality-tracking-cucumber5-jvm</module>
+        <module>aquality-tracking-cucumber4-jvm</module>
     </modules>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.aquality-automation</groupId>
     <artifactId>aquality-tracking-integrations</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 
     <name>Aquality Tracking integrations Libraries</name>
     <description>Aquality Tracking integration libraries for JVM-based test frameworks.</description>


### PR DESCRIPTION
- Implemented adaptor for Cucumber 4
- Updated Test model
- Fix issue with request headers for Attachments endpoint
- Refactored TestCaseNameParser

Note: SonarQube shows duplication 33%. Unfortunetelly, it is not possible to get rid of duplicated code, because of different versions of Cucumber in plugins.

resolves #3 